### PR TITLE
feat: adjunt task execution role in order to support production role

### DIFF
--- a/update_ecs_inntance.py
+++ b/update_ecs_inntance.py
@@ -2,6 +2,7 @@ import boto3
 import click
 import json
 
+
 def get_current_task_definition(client, cluster, service):
     response = client.describe_services(cluster=cluster, services=[service])
     current_task_arn = response["services"][0]["taskDefinition"]
@@ -10,20 +11,27 @@ def get_current_task_definition(client, cluster, service):
     print(current_task_arn)
     return client.describe_task_definition(taskDefinition=current_task_arn)
 
+
+PROD_TASK_ROLE = "production_ecs_task_execution_role"
+DEV_TASK_ROLE = "dev_ecs_task_execution_role"
+
+
 @click.command()
 @click.option("--cluster", help="Name of the ECS cluster", required=True)
 @click.option("--service", help="Name of the ECS service", required=True)
 @click.option("--image", help="Docker image URL for the updated application", required=True)
 @click.option("--username-secret-arn", help="Username ARN for the database credentials secret", required=True)
 @click.option("--password-secret-arn", help="Password ARN for the database credentials secret", required=True)
+@click.option("--target-env", help="JSON string of environment variables", required=False)
 @click.option("--env-vars", help="JSON string of environment variables", required=True)
-def deploy(cluster, service, image, username_secret_arn, password_secret_arn, env_vars):
+def deploy(cluster, service, image, username_secret_arn, password_secret_arn, target_env, env_vars):
     client = boto3.client("ecs")
 
     # Fetch the current task definition
     print("Fetching current task definition...")
     response = get_current_task_definition(client, cluster, service)
-    container_definition = response["taskDefinition"]["containerDefinitions"][0].copy()
+    container_definition = response["taskDefinition"]["containerDefinitions"][0].copy(
+    )
 
     # Update the container definition with the new image
     container_definition["image"] = image
@@ -41,6 +49,8 @@ def deploy(cluster, service, image, username_secret_arn, password_secret_arn, en
     # Register a new task definition
     print("Registering new task definition...")
 
+    task_execution_role = PROD_TASK_ROLE if target_env == "production" else DEV_TASK_ROLE
+
     response = client.register_task_definition(
         family=response["taskDefinition"]["family"],
         volumes=response["taskDefinition"]["volumes"],
@@ -49,8 +59,8 @@ def deploy(cluster, service, image, username_secret_arn, password_secret_arn, en
         memory="512",  # Modify based on your needs
         networkMode="awsvpc",
         requiresCompatibilities=["FARGATE"],
-        executionRoleArn="dev_ecs_task_execution_role",
-        taskRoleArn="dev_ecs_task_execution_role",
+        executionRoleArn=task_execution_role,
+        taskRoleArn=task_execution_role,
     )
     new_task_arn = response["taskDefinition"]["taskDefinitionArn"]
     print(f"New task definition ARN: {new_task_arn}")
@@ -61,6 +71,7 @@ def deploy(cluster, service, image, username_secret_arn, password_secret_arn, en
         cluster=cluster, service=service, taskDefinition=new_task_arn,
     )
     print("Service updated!")
+
 
 if __name__ == "__main__":
     deploy()


### PR DESCRIPTION
# Description

On this change we are adding the new production IAM Role in order to deploy production tasks via deploy scripts.